### PR TITLE
Text not visible in light mode in `Scroll Count` component

### DIFF
--- a/fg/layouts/scroll-count.tsx
+++ b/fg/layouts/scroll-count.tsx
@@ -143,7 +143,7 @@ export default function ScrollCount() {
             width: open ? 420 : 280,
             borderRadius: open ? 22 : 11,
           }}
-          className="bg-background relative cursor-pointer overflow-hidden text-white"
+          className="bg-background relative cursor-pointer overflow-hidden"
           style={{ borderRadius: 22 }}
         >
           <header


### PR DESCRIPTION
## PR Summary
Thank you for creating Framer-ground!
While reading the documentation, I noticed an issue where the text is not displaying properly in light mode, and I’m submitting this PR to fix it.

## Description

The `Scroll Count` component currently has an issue where text is not visible in `light mode` but is visible in `dark mode`.
This is due to the text color not adjusting correctly for light mode, making it blend into the background in light mode.

## Steps to reproduce
1. Open the application and ensure that light mode is enabled.
2. Navigate to the page containing the Scroll Count component.
3. Observe that the text inside the component is not visible in light mode, even though it is visible in dark mode.

## Expected behavior
The text inside the Scroll Count component should be clearly visible in both light and dark modes.

## Actual behavior
The text inside the Scroll Count component is not visible in light mode, but it appears correctly in dark mode.

## Screenshots
### Before
|   not open (light mode)   |     open  (light mode)  |   not open (dark mode)  |     open  (dark mode)   |
| :---:             |       :---:              | :---:         | :---:       |
| ![image](https://github.com/user-attachments/assets/6c3bbc18-77ca-4e8c-8283-df465d012e67)  |   ![image](https://github.com/user-attachments/assets/fb9d5f1b-cb34-4d73-9984-cdb20bc898cd) | ![image](https://github.com/user-attachments/assets/14cefb82-fe51-478e-acf2-c91c8d2002b1)  | ![image](https://github.com/user-attachments/assets/330b25c6-68b1-4cda-aa5a-79be5a18feaf) |


### After
|   not open     |     open       | 
| :---:             |       :---:              |
| ![image](https://github.com/user-attachments/assets/95a5b5f9-e566-43b1-89c4-b8b02198970e)   |   ![image](https://github.com/user-attachments/assets/d57b7083-4099-4e7c-a216-f0c3e52c9aad)  |






