### PR TITLE
Fix: Display the dates of the previous month in the correct order

### DIFF
--- a/fg/cards/calendar.tsx
+++ b/fg/cards/calendar.tsx
@@ -43,7 +43,7 @@ const Calendar = () => {
     // Add days from the previous month if the month doesn't start on Sunday
     if (startDayOfMonth > 0) {
       for (let i = startDayOfMonth - 1; i >= 0; i--) {
-        daysArray.unshift({
+        daysArray.push({
           day: daysInPreviousMonth - i,
           currentMonth: false, // mark as previous month
         });


### PR DESCRIPTION
addresses #12 

push the dates of the previous month instead of unshifting them from the start of the calendar array which led to dates being reversed